### PR TITLE
#29: fix keyboard dismiss on back button press

### DIFF
--- a/base/src/main/java/mf/irregex/keyboard/MyInputMethodService.kt
+++ b/base/src/main/java/mf/irregex/keyboard/MyInputMethodService.kt
@@ -235,7 +235,21 @@ class MyInputMethodService : InputMethodService(), OnKeyboardActionListener {
     }
 
     override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
-        if (PROCESS_HARD_KEYS && event != null) return translateKeyDown(keyCode, event)
+        when (keyCode) {
+            // The InputMethodService already takes care of the back
+            // key for us, to dismiss the input method if it is shown.
+            KeyEvent.KEYCODE_BACK ->
+                if (event?.repeatCount == 0 && keyboardView != null) {
+                    if (keyboardView!!.handleBack()) {
+                        return true
+                    }
+                }
+            else -> {
+                if (PROCESS_HARD_KEYS && event != null) {
+                    return translateKeyDown(keyCode, event)
+                }
+            }
+        }
         return super.onKeyDown(keyCode, event)
     }
 
@@ -542,7 +556,8 @@ class MyInputMethodService : InputMethodService(), OnKeyboardActionListener {
     private fun initPreferences(): Boolean {
         val window = getSystemService(WINDOW_SERVICE) as WindowManager
         val orientation = resources.configuration.orientation
-        val heightMultiplier = if (orientation == Configuration.ORIENTATION_LANDSCAPE) 1.7f else 1f
+        val heightMultiplier =
+            if (orientation == Configuration.ORIENTATION_LANDSCAPE) 1.7f else 1f
         val prefs = PreferenceManager.getDefaultSharedPreferences(this)
         val previousKeyHeight = keyHeight
         val previousLayout = keyboardLayout


### PR DESCRIPTION
#### What changes does this PR bring?

This change fixes and issue that dismisses the active view on back press when keyboard is inflated. 

#### Issue Reference

#29 

#### Screenshots

<table><tr><td align="center"><h3>Before</h3>
<img src='https://user-images.githubusercontent.com/2580981/109598396-3e86fc80-7ae7-11eb-9171-3e5e27a1d7d3.gif' alt='before' width="300"/>
</td><td align="center"><h3>After</h3>
<img src='https://user-images.githubusercontent.com/2580981/109598404-4181ed00-7ae7-11eb-885a-77648e052127.gif' alt='after' width="300"/>
</td></tr></table>

#### Additional details

None

#### Check all of the following

- [x] This PR does not conflict with target branch
- [x] I have appropriately labelled this PR
- [x] I have added appropriate issue reference