### PR TITLE
37: add alternate keys

### DIFF
--- a/base/src/main/res/drawable/ic_close.xml
+++ b/base/src/main/res/drawable/ic_close.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="@color/keyboardTextColor"
+      android:pathData="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"/>
+</vector>

--- a/base/src/main/res/layout/keyboard_popkey.xml
+++ b/base/src/main/res/layout/keyboard_popkey.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    style="@style/PopoverKey"
+    android:layout_width="0dp"
+    android:layout_height="wrap_content"
+    android:layout_weight="10" />

--- a/base/src/main/res/layout/keyboard_popup.xml
+++ b/base/src/main/res/layout/keyboard_popup.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/key_background"
+    android:orientation="horizontal">
+
+    <android.inputmethodservice.KeyboardView
+        android:id="@android:id/keyboardView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/transparent"
+        android:keyBackground="@color/transparent"
+        android:keyTextColor="@color/keyboardTextColor"
+        android:keyTextSize="22sp"
+        android:keyPreviewLayout="@null"
+        android:popupLayout="@null" />
+
+    <androidx.appcompat.widget.AppCompatImageButton
+        android:id="@android:id/closeButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="8dp"
+        android:clickable="true"
+        android:focusable="true"
+        android:alpha="0.5"
+        app:srcCompat="@drawable/ic_close" />
+</LinearLayout>

--- a/base/src/main/res/layout/keyboard_view.xml
+++ b/base/src/main/res/layout/keyboard_view.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_alignParentBottom="true"
@@ -16,6 +15,8 @@
         android:background="@color/keyboardBackground"
         android:keyBackground="@drawable/key_background"
         android:keyPreviewLayout="@null"
-        android:keyTextColor="@color/keyboardTextColor" />
+        android:popupLayout="@layout/keyboard_popup"
+        android:keyTextColor="@color/keyboardTextColor"
+        android:shadowRadius="0" />
 
 </LinearLayout>

--- a/base/src/main/res/values/colors.xml
+++ b/base/src/main/res/values/colors.xml
@@ -7,9 +7,11 @@
     <color name="colorAccent">@color/colorPrimary</color>
     <color name="ic_launcher_background">#E6E6E6</color>
     <color name="splash_background">#ddd</color>
+    <color name="transparent">#0000</color>
 
     <!-- style colors -->
     <color name="keyboardBackground">#333333</color>
+    <color name="keyboardPreviewBackground">#454545</color>
     <color name="keyboardTextColor">@android:color/white</color>
     <color name="keyboardDivider">#99111111</color>
     <color name="activity_bg">#f2f2f2</color>

--- a/base/src/main/res/values/strings.xml
+++ b/base/src/main/res/values/strings.xml
@@ -67,6 +67,18 @@
         <item>5</item>
     </string-array>
 
+    <string name="alternates_for_a">àáâäæãåā</string>
+    <string name="alternates_for_c">çćč</string>
+    <string name="alternates_for_e">èéêëēėę</string>
+    <string name="alternates_for_i">îïíīįì</string>
+    <string name="alternates_for_l">ł</string>
+    <string name="alternates_for_n">ñń</string>
+    <string name="alternates_for_o">ôöòóœøōõ</string>
+    <string name="alternates_for_s">ßśš</string>
+    <string name="alternates_for_u">ûüùúū</string>
+    <string name="alternates_for_y">ÿ</string>
+    <string name="alternates_for_z">žźż</string>
+
     <!-- style names -->
     <string name="name_frowny_faces">Frowny</string>
     <string name="name_happy_faces">Happy</string>

--- a/base/src/main/res/values/theme.xml
+++ b/base/src/main/res/values/theme.xml
@@ -22,4 +22,14 @@
         <item name="android:windowFullscreen">true</item>
         <item name="android:windowContentOverlay">@null</item>
     </style>
+
+    <style name="PopoverKey">
+        <item name="android:background">@color/transparent</item>
+        <item name="android:textColor">@color/keyboardTextColor</item>
+        <item name="android:paddingRight">6dp</item>
+        <item name="android:paddingTop">4dp</item>
+        <item name="android:textSize">10sp</item>
+        <item name="android:gravity">right</item>
+        <item name="android:textStyle">bold</item>
+    </style>
 </resources>

--- a/base/src/main/res/xml/keyboard_azerty.xml
+++ b/base/src/main/res/xml/keyboard_azerty.xml
@@ -5,37 +5,38 @@
     android:verticalGap="0dp"
     android:keyHeight="7%p">
     <Row>
-        <Key android:keyLabel="a"  android:keyEdgeFlags="left"/>
-        <Key android:keyLabel="z"/>
-        <Key android:keyLabel="e"/>
+        <Key android:keyEdgeFlags="left"
+             android:keyLabel="a" android:popupCharacters="@string/alternates_for_a" android:popupKeyboard="@xml/keyboard_popup"/>
+        <Key android:keyLabel="z" android:popupCharacters="@string/alternates_for_z" android:popupKeyboard="@xml/keyboard_popup" />
+        <Key android:keyLabel="e" android:popupCharacters="@string/alternates_for_e" android:popupKeyboard="@xml/keyboard_popup"/>
         <Key android:keyLabel="r"/>
         <Key android:keyLabel="t"/>
-        <Key android:keyLabel="y"/>
-        <Key android:keyLabel="u"/>
-        <Key android:keyLabel="i"/>
-        <Key android:keyLabel="o"/>
+        <Key android:keyLabel="y" android:popupCharacters="@string/alternates_for_y" android:popupKeyboard="@xml/keyboard_popup"/>
+        <Key android:keyLabel="u" android:popupCharacters="@string/alternates_for_u" android:popupKeyboard="@xml/keyboard_popup"/>
+        <Key android:keyLabel="i" android:popupCharacters="@string/alternates_for_i" android:popupKeyboard="@xml/keyboard_popup"/>
+        <Key android:keyLabel="o" android:popupCharacters="@string/alternates_for_o" android:popupKeyboard="@xml/keyboard_popup"/>
         <Key android:keyLabel="p" android:keyEdgeFlags="right"/>
     </Row>
     <Row>
         <Key android:keyLabel="q" android:keyEdgeFlags="left"/>
-        <Key android:keyLabel="s"/>
+        <Key android:keyLabel="s" android:popupCharacters="@string/alternates_for_s" android:popupKeyboard="@xml/keyboard_popup"/>
         <Key android:keyLabel="d"/>
         <Key android:keyLabel="f"/>
         <Key android:keyLabel="g"/>
         <Key android:keyLabel="h"/>
         <Key android:keyLabel="j"/>
         <Key android:keyLabel="k"/>
-        <Key android:keyLabel="l" />
+        <Key android:keyLabel="l" android:popupCharacters="@string/alternates_for_l" android:popupKeyboard="@xml/keyboard_popup" />
         <Key android:keyLabel="m" android:keyEdgeFlags="right"/>
     </Row>
     <Row>
         <Key android:codes="-1" android:keyIcon="@drawable/ic_arrow_up_bold_outline" android:keyWidth="15%p" android:keyEdgeFlags="left"/>
         <Key android:keyLabel="w"/>
         <Key android:keyLabel="x"/>
-        <Key android:keyLabel="c"/>
+        <Key android:keyLabel="c" android:popupCharacters="@string/alternates_for_c" android:popupKeyboard="@xml/keyboard_popup" />
         <Key android:keyLabel="v"/>
         <Key android:keyLabel="b"/>
-        <Key android:keyLabel="n"/>
+        <Key android:keyLabel="n" android:popupCharacters="@string/alternates_for_n" android:popupKeyboard="@xml/keyboard_popup"/>
         <Key android:keyLabel="'"/>
         <Key android:codes="-5"  android:keyIcon="@drawable/ic_backspace_outline"  android:keyWidth="15%p" android:isRepeatable="true" android:keyEdgeFlags="right"/>
     </Row>

--- a/base/src/main/res/xml/keyboard_popup.xml
+++ b/base/src/main/res/xml/keyboard_popup.xml
@@ -1,0 +1,9 @@
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+    android:keyBackground="@drawable/key_background"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:horizontalGap="0px"
+    android:keyWidth="10%p"
+    android:keyHeight="7%p"
+    android:verticalGap="0px">
+</Keyboard>

--- a/base/src/main/res/xml/keyboard_qwerty.xml
+++ b/base/src/main/res/xml/keyboard_qwerty.xml
@@ -20,7 +20,7 @@
     </Row>
     <Row>
         <Key android:horizontalGap="5%p" android:keyEdgeFlags="left"
-             android:codes="97" android:keyLabel="a"  android:popupCharacters="@string/alternates_for_a" android:popupKeyboard="@xml/keyboard_popup"/>
+             android:codes="97" android:keyLabel="a" android:popupCharacters="@string/alternates_for_a" android:popupKeyboard="@xml/keyboard_popup"/>
         <Key android:codes="115" android:keyLabel="s" android:popupCharacters="@string/alternates_for_s" android:popupKeyboard="@xml/keyboard_popup"/>
         <Key android:codes="100" android:keyLabel="d"/>
         <Key android:codes="102" android:keyLabel="f"/>

--- a/base/src/main/res/xml/keyboard_qwerty.xml
+++ b/base/src/main/res/xml/keyboard_qwerty.xml
@@ -1,42 +1,45 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
     android:keyWidth="10%p"
-    android:horizontalGap="0dp"
-    android:verticalGap="0dp"
     android:keyHeight="7%p"
-    >
+    android:horizontalGap="0dp"
+    android:verticalGap="0dp">
     <Row>
-        <Key android:codes="113" android:keyLabel="q"  android:keyEdgeFlags="left"/>
+        <Key android:keyEdgeFlags="left"
+             android:codes="113" android:keyLabel="q"/>
         <Key android:codes="119" android:keyLabel="w"/>
-        <Key android:codes="101" android:keyLabel="e"/>
+        <Key android:codes="101" android:keyLabel="e" android:popupCharacters="@string/alternates_for_e" android:popupKeyboard="@xml/keyboard_popup"/>
         <Key android:codes="114" android:keyLabel="r"/>
         <Key android:codes="116" android:keyLabel="t"/>
-        <Key android:codes="121" android:keyLabel="y"/>
-        <Key android:codes="117" android:keyLabel="u"/>
-        <Key android:codes="105" android:keyLabel="i"/>
-        <Key android:codes="111" android:keyLabel="o"/>
-        <Key android:codes="112" android:keyLabel="p" android:keyEdgeFlags="right"/>
+        <Key android:codes="121" android:keyLabel="y" android:popupCharacters="@string/alternates_for_y" android:popupKeyboard="@xml/keyboard_popup"/>
+        <Key android:codes="117" android:keyLabel="u" android:popupCharacters="@string/alternates_for_u" android:popupKeyboard="@xml/keyboard_popup"/>
+        <Key android:codes="105" android:keyLabel="i" android:popupCharacters="@string/alternates_for_i" android:popupKeyboard="@xml/keyboard_popup"/>
+        <Key android:codes="111" android:keyLabel="o" android:popupCharacters="@string/alternates_for_o" android:popupKeyboard="@xml/keyboard_popup"/>
+        <Key android:codes="112" android:keyLabel="p"
+            android:keyEdgeFlags="right"/>
     </Row>
     <Row>
-        <Key android:horizontalGap="5%p" android:codes="97" android:keyLabel="a" android:keyEdgeFlags="left"/>
-        <Key android:codes="115" android:keyLabel="s"/>
+        <Key android:horizontalGap="5%p" android:keyEdgeFlags="left"
+             android:codes="97" android:keyLabel="a"  android:popupCharacters="@string/alternates_for_a" android:popupKeyboard="@xml/keyboard_popup"/>
+        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="@string/alternates_for_s" android:popupKeyboard="@xml/keyboard_popup"/>
         <Key android:codes="100" android:keyLabel="d"/>
         <Key android:codes="102" android:keyLabel="f"/>
         <Key android:codes="103" android:keyLabel="g"/>
         <Key android:codes="104" android:keyLabel="h"/>
         <Key android:codes="106" android:keyLabel="j"/>
         <Key android:codes="107" android:keyLabel="k"/>
-        <Key android:codes="108" android:keyLabel="l" android:keyEdgeFlags="right"/>
+        <Key android:codes="108" android:keyLabel="l" android:popupCharacters="@string/alternates_for_l" android:popupKeyboard="@xml/keyboard_popup"
+             android:keyEdgeFlags="right"/>
     </Row>
     <Row>
         <Key android:codes="-1" android:keyIcon="@drawable/ic_arrow_up_bold_outline" android:keyWidth="15%p" android:keyEdgeFlags="left"/>
-        <Key android:codes="122" android:keyLabel="z"/>
-        <Key android:codes="120" android:keyLabel="x"/>
-        <Key android:codes="99" android:keyLabel="c"/>
-        <Key android:codes="118" android:keyLabel="v"/>
-        <Key android:codes="98" android:keyLabel="b"/>
-        <Key android:codes="110" android:keyLabel="n"/>
-        <Key android:codes="109" android:keyLabel="m"/>
+        <Key android:codes="122" android:keyLabel="z" android:popupCharacters="@string/alternates_for_z" android:popupKeyboard="@xml/keyboard_popup" />
+        <Key android:codes="120" android:keyLabel="x" />
+        <Key android:codes="99" android:keyLabel="c"  android:popupCharacters="@string/alternates_for_c" android:popupKeyboard="@xml/keyboard_popup" />
+        <Key android:codes="118" android:keyLabel="v" />
+        <Key android:codes="98" android:keyLabel="b" />
+        <Key android:codes="110" android:keyLabel="n" android:popupCharacters="@string/alternates_for_n" android:popupKeyboard="@xml/keyboard_popup" />
+        <Key android:codes="109" android:keyLabel="m" />
         <Key android:codes="-5"  android:keyIcon="@drawable/ic_backspace_outline"  android:keyWidth="15%p" android:isRepeatable="true" android:keyEdgeFlags="right"/>
     </Row>
     <Row android:rowEdgeFlags="bottom">

--- a/base/src/main/res/xml/keyboard_qwertz.xml
+++ b/base/src/main/res/xml/keyboard_qwertz.xml
@@ -8,34 +8,36 @@
     <Row>
         <Key android:codes="113" android:keyLabel="q"  android:keyEdgeFlags="left"/>
         <Key android:codes="119" android:keyLabel="w"/>
-        <Key android:codes="101" android:keyLabel="e"/>
+        <Key android:codes="101" android:keyLabel="e" android:popupCharacters="@string/alternates_for_e" android:popupKeyboard="@xml/keyboard_popup"/>
         <Key android:codes="114" android:keyLabel="r"/>
         <Key android:codes="116" android:keyLabel="t"/>
-        <Key android:codes="122" android:keyLabel="z"/>
-        <Key android:codes="117" android:keyLabel="u"/>
-        <Key android:codes="105" android:keyLabel="i"/>
-        <Key android:codes="111" android:keyLabel="o"/>
+        <Key android:codes="122" android:keyLabel="z" android:popupCharacters="@string/alternates_for_z" android:popupKeyboard="@xml/keyboard_popup" />
+        <Key android:codes="117" android:keyLabel="u" android:popupCharacters="@string/alternates_for_u" android:popupKeyboard="@xml/keyboard_popup"/>
+        <Key android:codes="105" android:keyLabel="i" android:popupCharacters="@string/alternates_for_i" android:popupKeyboard="@xml/keyboard_popup"/>
+        <Key android:codes="111" android:keyLabel="o" android:popupCharacters="@string/alternates_for_o" android:popupKeyboard="@xml/keyboard_popup"/>
         <Key android:codes="112" android:keyLabel="p" android:keyEdgeFlags="right"/>
     </Row>
     <Row>
-        <Key android:horizontalGap="5%p" android:codes="97" android:keyLabel="a" android:keyEdgeFlags="left"/>
-        <Key android:codes="115" android:keyLabel="s"/>
+        <Key android:horizontalGap="5%p" android:codes="97" android:keyLabel="a"
+            android:popupCharacters="@string/alternates_for_a" android:popupKeyboard="@xml/keyboard_popup"/>
+            android:keyEdgeFlags="left"/>
+        <Key android:codes="115" android:keyLabel="s" android:popupCharacters="@string/alternates_for_s" android:popupKeyboard="@xml/keyboard_popup"/>
         <Key android:codes="100" android:keyLabel="d"/>
         <Key android:codes="102" android:keyLabel="f"/>
         <Key android:codes="103" android:keyLabel="g"/>
         <Key android:codes="104" android:keyLabel="h"/>
         <Key android:codes="106" android:keyLabel="j"/>
         <Key android:codes="107" android:keyLabel="k"/>
-        <Key android:codes="108" android:keyLabel="l" android:keyEdgeFlags="right"/>
+        <Key android:codes="108" android:keyLabel="l" android:popupCharacters="@string/alternates_for_l" android:popupKeyboard="@xml/keyboard_popup" android:keyEdgeFlags="right"/>
     </Row>
     <Row>
         <Key android:codes="-1" android:keyIcon="@drawable/ic_arrow_up_bold_outline" android:keyWidth="15%p" android:keyEdgeFlags="left"/>
-        <Key android:codes="121" android:keyLabel="y"/>
+        <Key android:codes="121" android:keyLabel="y" android:popupCharacters="@string/alternates_for_y" android:popupKeyboard="@xml/keyboard_popup"/>
         <Key android:codes="120" android:keyLabel="x"/>
-        <Key android:codes="99" android:keyLabel="c"/>
+        <Key android:codes="99" android:keyLabel="c" android:popupCharacters="@string/alternates_for_c" android:popupKeyboard="@xml/keyboard_popup" />
         <Key android:codes="118" android:keyLabel="v"/>
         <Key android:codes="98" android:keyLabel="b"/>
-        <Key android:codes="110" android:keyLabel="n"/>
+        <Key android:codes="110" android:keyLabel="n" android:popupCharacters="@string/alternates_for_n" android:popupKeyboard="@xml/keyboard_popup" />
         <Key android:codes="109" android:keyLabel="m"/>
         <Key android:codes="-5"  android:keyIcon="@drawable/ic_backspace_outline"  android:keyWidth="15%p" android:isRepeatable="true" android:keyEdgeFlags="right"/>
     </Row>


### PR DESCRIPTION
#### What changes does this PR bring?

This change add accent characters into the popup layout for all current alpha-keyboards (qwerty, azerty, qwertz).

#### Issue Reference

#37 

#### Screenshots

<img width="450" alt="Screen Shot 2021-03-02 at 9 06 36 PM" src="https://user-images.githubusercontent.com/2580981/109741504-32f50d80-7b9b-11eb-8fd9-75466e774725.png">

#### Additional details

Ideally this the popup would disappear when moving outside the view, but based on various random and scattered bits of info of how to achieve that requires implementing custom keyboardView (see #46) and overriding the draw methods. For now this is what it will be. It may not be ideal (or pretty) but it allows typing these characters. 

Also the background overlay does not dim out the extra toolbar, because it is "outside", but can fix that later, it's not a big deal.

<img width="462" alt="Screen Shot 2021-03-02 at 9 12 34 PM" src="https://user-images.githubusercontent.com/2580981/109741892-07beee00-7b9c-11eb-9aac-5f92d0fef811.png">


#### Check all of the following

- [x] This PR does not conflict with target branch
- [X] I have appropriately labelled this PR
- [X] I have added appropriate issue reference