### PR TITLE
47: adjust minimum key height

### DIFF
--- a/base/src/main/res/values/strings.xml
+++ b/base/src/main/res/values/strings.xml
@@ -51,22 +51,6 @@
         <item>3</item>
     </string-array>
 
-    <string-array name="settings_key_height_array">
-        <item>1 - shortest</item>
-        <item>2 - shorter</item>
-        <item>3 - normal</item>
-        <item>4 - taller</item>
-        <item>5 - tallest</item>
-    </string-array>
-
-    <string-array name="settings_key_height_values_array">
-        <item>1</item>
-        <item>2</item>
-        <item>3</item>
-        <item>4</item>
-        <item>5</item>
-    </string-array>
-
     <string name="alternates_for_a">àáâäæãåā</string>
     <string name="alternates_for_c">çćč</string>
     <string name="alternates_for_e">èéêëēėę</string>

--- a/base/src/main/res/xml/root_preferences.xml
+++ b/base/src/main/res/xml/root_preferences.xml
@@ -31,7 +31,7 @@
             app:key="kdb_key_height"
             app:showSeekBarValue="true"
             android:icon="@drawable/ic_arrow_up_down"
-            app:min="6"
+            app:min="5"
             android:max="12"
             app:defaultValue="8"
             app:title="@string/key_height" />


### PR DESCRIPTION
#### What changes does this PR bring?

Reduce the min key height value from 6% to 5%.

#### Issue Reference

#47 

#### Screenshots

<img width="433" alt="Screen Shot 2021-03-02 at 9 26 59 PM" src="https://user-images.githubusercontent.com/2580981/109743031-0a224780-7b9e-11eb-9772-03e6a836bdf1.png">

At 5% height it looks like this:

<img width="465" alt="Screen Shot 2021-03-02 at 9 27 31 PM" src="https://user-images.githubusercontent.com/2580981/109743082-1d351780-7b9e-11eb-9230-a59db619e176.png">

<img width="898" alt="Screen Shot 2021-03-02 at 9 29 04 PM" src="https://user-images.githubusercontent.com/2580981/109743218-54a3c400-7b9e-11eb-90ff-fc3648aeffc8.png">

#### Additional details

At 4% the keys no longer fit and are drawn outside the key. Should try a few more devices though.

#### Check all of the following

- [x] This PR does not conflict with target branch
- [x] I have appropriately labelled this PR
- [x] I have added appropriate issue reference