### PR TITLE
fix zalgo name since it is randomized (#5)

### DIFF
--- a/base/src/main/java/mf/irregex/styles/AppTextStyle.kt
+++ b/base/src/main/java/mf/irregex/styles/AppTextStyle.kt
@@ -19,7 +19,7 @@ abstract class AppTextStyle(
     val styleId: String
         get() = id
 
-    val styledName: String
+    open val styledName: String
         get() = encode(name)!!
 
     val isReversed: Boolean

--- a/base/src/main/java/mf/irregex/styles/Zalgo.kt
+++ b/base/src/main/java/mf/irregex/styles/Zalgo.kt
@@ -20,9 +20,13 @@ class Zalgo internal constructor(
     // randomization 70%, height goes from 30 to 100.
     private val randomization = 100 // 0-100%
 
+    private val encodedName: String
+
     var diacriticsTop = ArrayList<Char>()
     var diacriticsMiddle = ArrayList<Char>()
     var diacriticsBottom = ArrayList<Char>()
+    override val styledName: String
+        get() = encodedName
 
     init {
         for (i in 768..789) {
@@ -73,6 +77,7 @@ class Zalgo internal constructor(
         diacriticsBottom.add((863).toChar())
         diacriticsTop.add((864).toChar())
         diacriticsTop.add((865).toChar())
+        encodedName = encode(name)!!
     }
 
     private fun getRandomChar(input: ArrayList<Char>): Char {


### PR DESCRIPTION
#### What changes does this PR bring?

zalgo style is randomized so rendering it always re-encodes the name differently. This change makes the styled name fixed.